### PR TITLE
docs: updates CODE_OF_CONDUCT.md to link to the CNCF CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,7 @@
 # OSCAL Compass - Code of Conduct
 
-This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+**By participating, you are expected to uphold this code.**
+
+*This file is a mirror of https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md*

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@ The OSCAL Compass project is set of tools that enable the creation, validation, 
 
 ## Get Started with OSCAL Compass
 
-Check out the [Community README](https://github.com/oscal-compass/community/blob/main/README.md) to get started with using and contributing to the project. The README also details all the ways to collaborate with project maintainers and your fellow users of OSCAL Compass tools.
+Check out the [Community README](https://github.com/oscal-compass/community/blob/main/README.md) to get started with using and contributing to the project. The README also details all the ways to collaborate with project maintainers and your fellow users of OSCAL Compass tools. Anyone is welcome to participate and contribute provided they follow the OSCAL Compass [Code of Conduct](https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md).
 
 ## Learn about the projects
 


### PR DESCRIPTION
- Update organization Code of Conduct for project to inherit
- Adds a link to the Code of Conduct in the organization profile