### PR TITLE
docs: update README.md with CNCF information

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,3 @@
 # OSCAL Compass - Code of Conduct
 
-We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
-
-**By participating, you are expected to uphold this code.**
-
-*This file is a mirror of https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md*
+The OSCAL Compass Code of Conduct is defined in the [community repository](https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md)

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,8 +1,10 @@
-# <img alt="OSCAL Compass Logo" width="100px" src="https://raw.githubusercontent.com/oscal-compass/community/main/assets/oscal-compass-icon-800x800.png" style="vertical-align: middle;" /> OSCAL Compass
+# <img alt="OSCAL Compass Logo" width="100px" src="https://raw.githubusercontent.com/oscal-compass/community/main/assets/oscal-compass-icon-800x800.png" style="vertical-align: middle;" /> Welcome to the OSCAL Compass project
 
 The OSCAL Compass project is set of tools that enable the creation, validation, and governance of documentation artifacts for compliance needs. It leverages NIST's OSCAL ([Open Security Controls Assessment Language](https://pages.nist.gov/OSCAL/)) as a standard data format for interchange between tools and people, and provides an opinionated approach to OSCAL adoption.
 
-## Get Started with OSCAL Compass
+The OSCAL Compass project is hosted by the [Cloud Native Computing Foundation (CNCF)](https://cncf.io)
+
+## Get Started
 
 Check out the [Community README](https://github.com/oscal-compass/community/blob/main/README.md) to get started with using and contributing to the project. The README also details all the ways to collaborate with project maintainers and your fellow users of OSCAL Compass tools. Anyone is welcome to participate and contribute provided they follow the OSCAL Compass [Code of Conduct](https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
# This change includes

- Better alignment with the CNCF project README.md template
- Reduce duplicate in the CoC by just directly pointing to the community repo